### PR TITLE
Enable testing and coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,20 @@ compiler:
   - gcc
 script: 
   - mkdir build && cd build
-  - cmake ..
-  - make && make test
+  - cmake -DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug ..
+  - make -j$(nproc) && make test
+addons:
+  apt:
+    packages: lcov
+after_success:
+  # Create lcov report
+  # capture coverage info
+  - lcov --directory . --capture --output-file coverage.info
+  # filter out system and extra files.
+  # To also not include test code in coverage add them with full path to the patterns: '*/tests/*'
+  - lcov --remove coverage.info '/usr/*' --output-file coverage.info
+  # output coverage data for debugging (optional)
+  - lcov --list coverage.info
+  # Uploading to CodeCov
+  # '-f' specifies file(s) to use and disables manual coverage gathering and file search which has already been done above
+  - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ dist: xenial
 compiler:
   - clang
   - gcc
+env:
+  - CTEST_OUTPUT_ON_FAILURE=1
 script: 
   - mkdir build && cd build
-  - cmake -DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug ..
+  - cmake -DCODE_COVERAGE=ON ..
   - make -j$(nproc) && make test
 addons:
   apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(ismcsolver)
 cmake_minimum_required(VERSION 3.12.0)
 set(CMAKE_CXX_STANDARD 11)
 
+include(CTest)
 find_package(Threads REQUIRED)
 find_package(Doxygen)
 
@@ -20,13 +21,37 @@ set(headers
     ${include_dir}/execution.h
 )
 
-add_subdirectory(test)
-
 add_library(ismcsolver INTERFACE)
 target_link_libraries(ismcsolver INTERFACE Threads::Threads)
 target_include_directories(ismcsolver INTERFACE include)
 target_sources(ismcsolver INTERFACE ${headers})
 install(FILES ${headers} DESTINATION include)
+
+
+# Tests
+option (BUILD_TESTING ON)
+if (BUILD_TESTING AND (PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR))
+    enable_testing()
+    add_subdirectory(test)
+endif()
+
+# Code coverage
+add_library(coverage_config INTERFACE)
+
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
+if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # Add required flags (GCC & LLVM/Clang)
+  target_compile_options(coverage_config INTERFACE
+    -O0        # no optimization
+    -g         # generate debug info
+    --coverage # sets all required flags
+  )
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    target_link_options(coverage_config INTERFACE --coverage)
+  else()
+    target_link_libraries(coverage_config INTERFACE --coverage)
+  endif()
+endif(CODE_COVERAGE)
 
 if(DOXYGEN_FOUND)
     set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   else()
     target_link_libraries(coverage_config INTERFACE --coverage)
   endif()
-endif(CODE_COVERAGE)
+endif()
 
 if(DOXYGEN_FOUND)
     set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(headers
 )
 
 add_library(ismcsolver INTERFACE)
+target_compile_features(ismcsolver INTERFACE cxx_std_11)
 target_link_libraries(ismcsolver INTERFACE Threads::Threads)
 target_include_directories(ismcsolver INTERFACE include)
 target_sources(ismcsolver INTERFACE ${headers})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,25 +28,21 @@ target_include_directories(ismcsolver INTERFACE include)
 target_sources(ismcsolver INTERFACE ${headers})
 install(FILES ${headers} DESTINATION include)
 
-
 # Tests
-option (BUILD_TESTING ON)
+option(BUILD_TESTING ON)
+
 if (BUILD_TESTING AND (PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR))
     enable_testing()
     add_subdirectory(test)
 endif()
 
 # Code coverage
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
 add_library(coverage_config INTERFACE)
 
-option(CODE_COVERAGE "Enable coverage reporting" OFF)
 if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  # Add required flags (GCC & LLVM/Clang)
-  target_compile_options(coverage_config INTERFACE
-    -O0        # no optimization
-    -g         # generate debug info
-    --coverage # sets all required flags
-  )
+  # Set debug + coverage
+  target_compile_options(coverage_config INTERFACE -O0 -g --coverage)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
     target_link_options(coverage_config INTERFACE --coverage)
   else()
@@ -54,6 +50,7 @@ if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   endif()
 endif()
 
+# Documentation
 if(DOXYGEN_FOUND)
     set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
     set(DOXYGEN_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/docs)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,28 +4,25 @@
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-include(CTest)
 include(Catch)
 
-if(BUILD_TESTING)
-    # Precompile Catch2 to limit compilation times
-    add_library(testmain OBJECT main.cpp)
+# Precompile Catch2 to limit compilation times
+add_library(testmain OBJECT main.cpp)
 
-    set(game_src knockoutwhist.cpp)
-    set(testlibs testmain ismcsolver)
+set(game_src knockoutwhist.cpp)
+set(testlibs testmain ismcsolver)
 
-    add_executable(benchmark benchmark.cpp ${game_src})
-    target_link_libraries(benchmark ${testlibs})
+add_executable(benchmark benchmark.cpp ${game_src})
+target_link_libraries(benchmark ${testlibs})
 
-    add_executable(gametest gametest.cpp ${game_src})
-    target_link_libraries(gametest ${testlibs})
-    catch_discover_tests(gametest)
+add_executable(gametest gametest.cpp ${game_src})
+target_link_libraries(gametest ${testlibs})
+catch_discover_tests(gametest)
 
-    add_executable(nodetest nodetest.cpp ${game_src})
-    target_link_libraries(nodetest ${testlibs})
-    catch_discover_tests(nodetest)
+add_executable(nodetest nodetest.cpp ${game_src})
+target_link_libraries(nodetest ${testlibs})
+catch_discover_tests(nodetest)
 
-    add_executable(solvertest solvertest.cpp ${game_src})
-    target_link_libraries(solvertest ${testlibs})
-    catch_discover_tests(solvertest)
-endif()
+add_executable(solvertest solvertest.cpp ${game_src})
+target_link_libraries(solvertest ${testlibs})
+catch_discover_tests(solvertest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ include(Catch)
 add_library(testmain OBJECT main.cpp)
 
 set(game_src knockoutwhist.cpp)
-set(testlibs testmain ismcsolver)
+set(testlibs testmain ismcsolver coverage_config)
 
 add_executable(benchmark benchmark.cpp ${game_src})
 target_link_libraries(benchmark ${testlibs})

--- a/test/gametest.cpp
+++ b/test/gametest.cpp
@@ -26,10 +26,19 @@ void doValidMove(ISMCTS::Game<Card> &game)
 
 }
 
+TEST_CASE("Check RNG")
+{
+    std::mt19937 rng;
+
+    CHECK(rng.default_seed == 5489);
+    for (int i = 0; i < 9999; ++i)
+        rng();
+    REQUIRE(rng() == 4123659995);
+}
+
 TEST_CASE("Game is created in a predictable state", "[KnockoutWhist]")
 {
     KnockoutWhist game {2};
-    REQUIRE(std::mt19937::default_seed == 5489);
     static const std::vector<std::string> expectedMoves {"8D", "TS", "5H", "9H", "2H", "JC", "QD"};
 
     CHECK(game.currentPlayer() == 0);

--- a/test/gametest.cpp
+++ b/test/gametest.cpp
@@ -17,10 +17,10 @@ struct MockGame : public KnockoutWhist
 {
     MockGame() : KnockoutWhist {2}
     {
-        deal();
+        initialDeal();
     }
 
-    void deal()
+    void initialDeal()
     {
         m_trumpSuit = Card::Diamonds;
         m_playerCards[0] = {
@@ -116,7 +116,7 @@ TEST_CASE("Game terminates correctly", "[KnockoutWhist]")
     unsigned int turn {0};
     const unsigned int correctTurnCount {44};
 
-    while (!game.validMoves().empty() && turn < correctTurnCount) {
+    while (!game.validMoves().empty() ) {
         doValidMove(game);
         ++turn;
     }

--- a/test/gametest.cpp
+++ b/test/gametest.cpp
@@ -29,6 +29,7 @@ void doValidMove(ISMCTS::Game<Card> &game)
 TEST_CASE("Game is created in a predictable state", "[KnockoutWhist]")
 {
     KnockoutWhist game {2};
+    REQUIRE(std::mt19937::default_seed == 5489);
     static const std::vector<std::string> expectedMoves {"8D", "TS", "5H", "9H", "2H", "JC", "QD"};
 
     CHECK(game.currentPlayer() == 0);

--- a/test/gametest.cpp
+++ b/test/gametest.cpp
@@ -113,16 +113,14 @@ TEST_CASE("Game handles moves correctly", "[KnockoutWhist]")
 TEST_CASE("Game terminates correctly", "[KnockoutWhist]")
 {
     MockGame game;
+    // Maximum number of turns is nPlayers * (7 + 6 + ... + 1)
+    const unsigned int maxTurns {56};
     unsigned int turn {0};
-    const unsigned int correctTurnCount {44};
 
-    while (!game.validMoves().empty() ) {
-        doValidMove(game);
+    while (!game.validMoves().empty() && turn < maxTurns) {
+        CHECK_NOTHROW(doValidMove(game));
         ++turn;
     }
 
-    CHECK(turn == correctTurnCount);
     REQUIRE(game.validMoves().empty());
-    CHECK(game.getResult(0) == 1);
-    CHECK(game.getResult(1) == 0);
 }

--- a/test/knockoutwhist.cpp
+++ b/test/knockoutwhist.cpp
@@ -17,7 +17,8 @@ const unsigned DeckSize {52};
 }
 
 KnockoutWhist::KnockoutWhist(unsigned players)
-    : m_tricksLeft{7}
+    : m_urng{5489ul}
+    , m_tricksLeft{7}
     , m_numPlayers{std::min(std::max(players, 2u), 7u)}
     , m_player{0}
 {

--- a/test/knockoutwhist.cpp
+++ b/test/knockoutwhist.cpp
@@ -17,8 +17,7 @@ const unsigned DeckSize {52};
 }
 
 KnockoutWhist::KnockoutWhist(unsigned players)
-    : m_urng{5489ul}
-    , m_tricksLeft{7}
+    : m_tricksLeft{7}
     , m_numPlayers{std::min(std::max(players, 2u), 7u)}
     , m_player{0}
 {

--- a/test/knockoutwhist.h
+++ b/test/knockoutwhist.h
@@ -23,7 +23,7 @@ public:
     virtual double getResult(unsigned player) const override;
     friend std::ostream &operator<<(std::ostream &out, const KnockoutWhist &g);
 
-private:
+protected:
     using Player = unsigned;
     using Hand = std::vector<Card>;
     using Play = std::pair<Player,Card>;


### PR DESCRIPTION
It turns out that `std::shuffle` differs across C++ library implementations. Therefore the game tests no longer rely on a particular shuffling algorithm. Requirement of C++11 features is now also explicitly specified for compilation.